### PR TITLE
feat: optional node number

### DIFF
--- a/API.md
+++ b/API.md
@@ -44,6 +44,7 @@ new ContainerService(scope: Construct, id: string, props: ContainerServiceProps)
   * **vpc** (<code>[IVpc](#aws-cdk-aws-ec2-ivpc)</code>)  The VPC for the service. 
   * **bastion** (<code>boolean</code>)  Whether to create the bastion host. __*Default*__: false
   * **circuitBreaker** (<code>boolean</code>)  Whether to enable the ECS service deployment circuit breaker. __*Default*__: false
+  * **nodeCount** (<code>number</code>)  Number of keycloak node in the cluster. __*Default*__: 1
 
 
 
@@ -115,6 +116,7 @@ new KeyCloak(scope: Construct, id: string, props: KeyCloadProps)
 * **props** (<code>[KeyCloadProps](#cdk-keycloak-keycloadprops)</code>)  *No description*
   * **certificateArn** (<code>string</code>)  ACM certificate ARN to import. 
   * **bastion** (<code>boolean</code>)  Create a bastion host for debugging or trouble-shooting. __*Default*__: false
+  * **nodeCount** (<code>number</code>)  Number of keycloak node in the cluster. __*Default*__: 1
   * **vpc** (<code>[IVpc](#aws-cdk-aws-ec2-ivpc)</code>)  VPC for the workload. __*Optional*__
 
 
@@ -157,6 +159,7 @@ addKeyCloakContainerService(props: ContainerServiceProps): ContainerService
   * **vpc** (<code>[IVpc](#aws-cdk-aws-ec2-ivpc)</code>)  The VPC for the service. 
   * **bastion** (<code>boolean</code>)  Whether to create the bastion host. __*Default*__: false
   * **circuitBreaker** (<code>boolean</code>)  Whether to enable the ECS service deployment circuit breaker. __*Default*__: false
+  * **nodeCount** (<code>number</code>)  Number of keycloak node in the cluster. __*Default*__: 1
 
 __Returns__:
 * <code>[ContainerService](#cdk-keycloak-containerservice)</code>
@@ -178,6 +181,7 @@ Name | Type | Description
 **vpc** | <code>[IVpc](#aws-cdk-aws-ec2-ivpc)</code> | The VPC for the service.
 **bastion**? | <code>boolean</code> | Whether to create the bastion host.<br/>__*Default*__: false
 **circuitBreaker**? | <code>boolean</code> | Whether to enable the ECS service deployment circuit breaker.<br/>__*Default*__: false
+**nodeCount**? | <code>number</code> | Number of keycloak node in the cluster.<br/>__*Default*__: 1
 
 
 
@@ -207,6 +211,7 @@ Name | Type | Description
 -----|------|-------------
 **certificateArn** | <code>string</code> | ACM certificate ARN to import.
 **bastion**? | <code>boolean</code> | Create a bastion host for debugging or trouble-shooting.<br/>__*Default*__: false
+**nodeCount**? | <code>number</code> | Number of keycloak node in the cluster.<br/>__*Default*__: 1
 **vpc**? | <code>[IVpc](#aws-cdk-aws-ec2-ivpc)</code> | VPC for the workload.<br/>__*Optional*__
 
 

--- a/src/keycloak.ts
+++ b/src/keycloak.ts
@@ -23,6 +23,12 @@ export interface KeyCloadProps {
    * @default false
    */
   readonly bastion?: boolean;
+  /**
+   * Number of keycloak node in the cluster
+   *
+   * @default 1
+   */
+  readonly nodeCount?: number;
 }
 
 export class KeyCloak extends cdk.Construct {
@@ -39,6 +45,7 @@ export class KeyCloak extends cdk.Construct {
       keycloakSecret: this._generateKeycloakSecret(),
       certificate: certmgr.Certificate.fromCertificateArn(this, 'ACMCert', props.certificateArn),
       bastion: props.bastion,
+      nodeCount: props.nodeCount,
     });
   }
   public addDatabase(): Database {
@@ -47,7 +54,7 @@ export class KeyCloak extends cdk.Construct {
     });
   }
   public addKeyCloakContainerService(props: ContainerServiceProps) {
-    return new ContainerService(this, 'KeyCloakContainerSerivce', props );
+    return new ContainerService(this, 'KeyCloakContainerSerivce', props);
   }
   private _generateKeycloakSecret(): secretsmanager.ISecret {
     return new secretsmanager.Secret(this, 'KCSecret', {
@@ -146,6 +153,12 @@ export interface ContainerServiceProps {
    * @default false
    */
   readonly circuitBreaker?: boolean;
+  /**
+   * Number of keycloak node in the cluster
+   *
+   * @default 1
+   */
+  readonly nodeCount?: number;
 }
 
 export class ContainerService extends cdk.Construct {
@@ -225,7 +238,7 @@ export class ContainerService extends cdk.Construct {
       cluster,
       taskDefinition,
       circuitBreaker: props.circuitBreaker ? { rollback: true } : undefined,
-      desiredCount: 1,
+      desiredCount: props.nodeCount ?? 1,
       healthCheckGracePeriod: cdk.Duration.seconds(120),
     });
 


### PR DESCRIPTION
Make keycloak cluster node number optional. Default `1`.

